### PR TITLE
Remove version resolver

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,7 @@
-name-template: 'v$RESOLVED_VERSION'
-tag-template: 'v$RESOLVED_VERSION'
+# These will be overridden by the publish workflro and set to the new tag
+name-template: 'Next Release'
+tag-template: 'next'
+
 categories:
   - title: '🚀 Features'
     labels:
@@ -12,19 +14,10 @@ categories:
       - 'bug'
   - title: '📖 Documentation'
     label: 'documentation'
+
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
-version-resolver:
-  major:
-    labels:
-      - 'effver/macro'
-  minor:
-    labels:
-      - 'effver/meso'
-  patch:
-    labels:
-      - 'effver/micro'
-  default: patch
+
 template: |
   ## Changes
 

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  update_release_draft:
+  publish_release:
     permissions:
       # write permission is required to create a github release
       contents: write

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  publish_release:
+  update_release_draft:
     permissions:
       # write permission is required to create a github release
       contents: write


### PR DESCRIPTION
Remove version resolver and hard code drafted release to "Next Release". The release title and tag get overridden during the publish workflow added in #4 and set to the name of the new tag.