### PR TITLE
Don't create drafts on release commits

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -16,7 +16,11 @@ jobs:
       pull-requests: read
     runs-on: ubuntu-latest
     steps:
+      - name: Check if release commit
+        id: check_release_commit
+        run: git describe --exact-match --tags $(git rev-parse HEAD)
       - uses: release-drafter/release-drafter@v5
+        if: steps.check_release_commit.outcome != 'success'
         with:
           disable-autolabeler: true
         env:


### PR DESCRIPTION
Some projects create an empty commit on release and tag that commit. This means both the draft and publish workflows will run simultaneously and the race condition can mean the release doesn't get published as expedted.

This PR explores having the draft workflow check if the commit has been tagged, and if so it doesn't run the draft step.