### PR TITLE
Set full fetch depth

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Required to get tag history
       - name: Check if release commit
         id: check_release_commit
         run: git describe --exact-match --tags $(git rev-parse HEAD)


### PR DESCRIPTION
To be able to determine if the current commit is a tagged one we need the full git history.